### PR TITLE
fix: Out of bounds on player inventory crafting.

### DIFF
--- a/src/Inventory/CraftingTable.cpp
+++ b/src/Inventory/CraftingTable.cpp
@@ -75,7 +75,7 @@ bool CraftingTableInventory::on_pick(uint32_t layer, uint32_t index, ItemStack s
 void CraftingTableInventory::update_recipe()
 {
     InplaceVector<Id<Item>, RECIPE_SIZE> grid;
-    for (size_t i = 0; i < RECIPE_SIZE; i++)
+    for (size_t i = 0; i < CRAFTING_GRID_SIZE; i++)
     {
         ItemStack s = m_container->get_stack(INGREDIENTS_LAYER, i);
         grid.push_back(s.item());

--- a/src/Inventory/PlayerInventory.cpp
+++ b/src/Inventory/PlayerInventory.cpp
@@ -223,8 +223,7 @@ bool PlayerInventory::on_pick(uint32_t layer, uint32_t index, ItemStack stack, I
 void PlayerInventory::update_recipe()
 {
     InplaceVector<Id<Item>, RECIPE_SIZE> grid;
-    println("{}", RECIPE_SIZE);
-    for (size_t i = 0; i < RECIPE_SIZE; i++)
+    for (size_t i = 0; i < CRAFTING_GRID_SIZE; i++)
     {
         ItemStack s = m_container->get_stack(INGREDIENTS_LAYER, i);
         grid.push_back(s.item());


### PR DESCRIPTION
Player inventory was out of bound when checking recipe since he was using RECIPE_SIZE (9) instead of CRAFTING_GRID_SIZE (4 in player inventory)